### PR TITLE
[CD-46874] added "deleteRDD" method

### DIFF
--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
@@ -197,8 +197,8 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
    * Some implementations may not support this operation and will throw
    * `UnsupportedOperationException`.
    */
-  def deleteRDD[U: ClassTag](other: RDD[(K, U)]): IndexedRDD[K, V] = other match {
-    case other: IndexedRDD[K, U] if partitioner == other.partitioner =>
+  def deleteRDD[V2: ClassTag](other: RDD[(K, V2)]): IndexedRDD[K, V] = other match {
+    case other: IndexedRDD[K, V2] if partitioner == other.partitioner =>
       this.zipIndexedRDDPartitions(other)(new DeleteZipper)
     case _ =>
       this.zipPartitionsWithOther(other.partitionBy(partitioner.get))(new OtherDeleteZipper)
@@ -353,8 +353,8 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
     }
   }
 
-  private class DeleteZipper[U: ClassTag] extends ZipPartitionsFunction[U, V] with Serializable {
-    def apply(thisIter: Iterator[IndexedRDDPartition[K, V]], otherIter: Iterator[IndexedRDDPartition[K, U]])
+  private class DeleteZipper[V2: ClassTag] extends ZipPartitionsFunction[V2, V] with Serializable {
+    def apply(thisIter: Iterator[IndexedRDDPartition[K, V]], otherIter: Iterator[IndexedRDDPartition[K, V2]])
       : Iterator[IndexedRDDPartition[K, V]] = {
       val thisPart = thisIter.next()
       val otherPart = otherIter.next()
@@ -362,8 +362,8 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
     }
   }
 
-  private class OtherDeleteZipper[U: ClassTag] extends OtherZipPartitionsFunction[U, V] with Serializable {
-    def apply(thisIter: Iterator[IndexedRDDPartition[K, V]], otherIter: Iterator[(K, U)])
+  private class OtherDeleteZipper[V2: ClassTag] extends OtherZipPartitionsFunction[V2, V] with Serializable {
+    def apply(thisIter: Iterator[IndexedRDDPartition[K, V]], otherIter: Iterator[(K, V2)])
       : Iterator[IndexedRDDPartition[K, V]] = {
       val thisPart = thisIter.next()
       Iterator(thisPart.delete(otherIter))

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
@@ -186,7 +186,7 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
    * `UnsupportedOperationException`.
    */
   def delete(ks: Array[K]): IndexedRDD[K, V] = {
-    val deletions = context.parallelize(ks.map(k => (k, ()))).partitionBy(partitioner.get)
+    val deletions = context.parallelize(ks.map(k => (k, ())))
     zipPartitionsWithOther(deletions)(new OtherDeleteZipper)
   }
 
@@ -201,7 +201,7 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
     case other: IndexedRDD[K, V2] if partitioner == other.partitioner =>
       this.zipIndexedRDDPartitions(other)(new DeleteZipper)
     case _ =>
-      this.zipPartitionsWithOther(other.partitionBy(partitioner.get))(new OtherDeleteZipper)
+      this.zipPartitionsWithOther(other)(new OtherDeleteZipper)
   }
 
   /** Applies a function to each partition of this IndexedRDD. */

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
@@ -357,7 +357,8 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
     def apply(thisIter: Iterator[IndexedRDDPartition[K, V]], otherIter: Iterator[IndexedRDDPartition[K, U]])
       : Iterator[IndexedRDDPartition[K, V]] = {
       val thisPart = thisIter.next()
-      Iterator(thisPart.delete(otherIter.map(_.iterator.map(_._1)).flatten))
+      val otherPart = otherIter.next()
+      Iterator(thisPart.delete(otherPart))
     }
   }
 
@@ -365,7 +366,7 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
     def apply(thisIter: Iterator[IndexedRDDPartition[K, V]], otherIter: Iterator[(K, U)])
       : Iterator[IndexedRDDPartition[K, V]] = {
       val thisPart = thisIter.next()
-      Iterator(thisPart.delete(otherIter.map(_._1)))
+      Iterator(thisPart.delete(otherIter))
     }
   }
 

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDD.scala
@@ -189,6 +189,18 @@ class IndexedRDD[K: ClassTag, V: ClassTag](
     val deletions = context.parallelize(ks.map(k => (k, ()))).partitionBy(partitioner.get)
     zipPartitionsWithOther(deletions)(new DeleteZipper)
   }
+  
+  /**
+   * Deletes any elements that have equal keys to elements in `other`. 
+   * Returns a new IndexedRDD that reflects the deletions.
+   *
+   * Some implementations may not support this operation and will throw
+   * `UnsupportedOperationException`.
+   */
+  def deleteByKey(other: RDD[(K, Unit)]): IndexedRDD[K, V] = {
+    //val deletions = other.partitionBy(partitioner.get)
+    zipPartitionsWithOther(other.partitionBy(partitioner.get))(new DeleteZipper)
+  }
 
   /** Applies a function to each partition of this IndexedRDD. */
   private def mapIndexedRDDPartitions[K2: ClassTag, V2: ClassTag](

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDPartition.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDPartition.scala
@@ -58,7 +58,11 @@ private[indexedrdd] abstract class IndexedRDDPartition[K, V] extends Serializabl
     throw new UnsupportedOperationException("modifications not supported")
 
   /** Deletes the specified keys. Returns a new IndexedRDDPartition that reflects the deletions. */
-  def delete(ks: Iterator[K]): IndexedRDDPartition[K, V] =
+  def delete[U: ClassTag](other: IndexedRDDPartition[K, U]): IndexedRDDPartition[K, V] =
+    throw new UnsupportedOperationException("modifications not supported")
+
+  /** Deletes the specified keys. Returns a new IndexedRDDPartition that reflects the deletions. */
+  def delete[U: ClassTag](other: Iterator[(K, U)]): IndexedRDDPartition[K, V] =
     throw new UnsupportedOperationException("modifications not supported")
 
   /** Maps each value, supplying the corresponding key and preserving the index. */

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDPartition.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDPartition.scala
@@ -58,11 +58,11 @@ private[indexedrdd] abstract class IndexedRDDPartition[K, V] extends Serializabl
     throw new UnsupportedOperationException("modifications not supported")
 
   /** Deletes the specified keys. Returns a new IndexedRDDPartition that reflects the deletions. */
-  def delete[U: ClassTag](other: IndexedRDDPartition[K, U]): IndexedRDDPartition[K, V] =
+  def delete[V2: ClassTag](other: IndexedRDDPartition[K, V2]): IndexedRDDPartition[K, V] =
     throw new UnsupportedOperationException("modifications not supported")
 
   /** Deletes the specified keys. Returns a new IndexedRDDPartition that reflects the deletions. */
-  def delete[U: ClassTag](other: Iterator[(K, U)]): IndexedRDDPartition[K, V] =
+  def delete[V2: ClassTag](other: Iterator[(K, V2)]): IndexedRDDPartition[K, V] =
     throw new UnsupportedOperationException("modifications not supported")
 
   /** Maps each value, supplying the corresponding key and preserving the index. */

--- a/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/impl/PARTPartition.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/spark/indexedrdd/impl/PARTPartition.scala
@@ -60,8 +60,8 @@ private[indexedrdd] class PARTPartition[K, V]
     this.withMap[V](newMap)
   }
 
-  override def delete[U: ClassTag](other: IndexedRDDPartition[K, U]) :IndexedRDDPartition[K, V] = other match {
-    case other: PARTPartition[K, U] =>
+  override def delete[V2: ClassTag](other: IndexedRDDPartition[K, V2]) :IndexedRDDPartition[K, V] = other match {
+    case other: PARTPartition[K, V2] =>
       val newMap = map.snapshot()
       for (kv <- other.iterator) {
         newMap.delete(kSer.toBytes(kv._1))
@@ -71,7 +71,7 @@ private[indexedrdd] class PARTPartition[K, V]
       delete(other.iterator)
   }
 
-  override def delete[U: ClassTag](other: Iterator[(K, U)]): IndexedRDDPartition[K, V] =
+  override def delete[V2: ClassTag](other: Iterator[(K, V2)]): IndexedRDDPartition[K, V] =
     delete(PARTPartition(other))
 
   override def mapValues[V2: ClassTag](f: (K, V) => V2): IndexedRDDPartition[K, V2] = {

--- a/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
@@ -215,6 +215,13 @@ class UpdatableIndexedRDDSuite extends IndexedRDDSuite {
     assert(ps.delete(Array(0L)).collect.toSet === (1 to n).map(x => (x.toLong, x)).toSet)
     assert(ps.delete(Array(-1L)).collect.toSet === (0 to n).map(x => (x.toLong, x)).toSet)
   }
+
+  test("deleteByKey") {
+    val n = 10
+    val irdd = pairs(sc, n).cache()
+    var prdd = sc.parallelize((0 to 5).map(x => (x.toLong, ())), 5)
+    assert(irdd.deleteByKey(prdd).collect().toSet === (6 to n).map(x => (x.toLong, x)).toSet)
+  }
 }
 
 // Declared outside of test suite to avoid closure capture

--- a/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
@@ -216,11 +216,15 @@ class UpdatableIndexedRDDSuite extends IndexedRDDSuite {
     assert(ps.delete(Array(-1L)).collect.toSet === (0 to n).map(x => (x.toLong, x)).toSet)
   }
 
-  test("deleteByKey") {
-    val n = 10
+  test("deleteRDD") {
+    val n = 100
     val irdd = pairs(sc, n).cache()
-    var prdd = sc.parallelize((0 to 5).map(x => (x.toLong, ())), 5)
-    assert(irdd.deleteByKey(prdd).collect().toSet === (6 to n).map(x => (x.toLong, x)).toSet)
+    val prdd = sc.parallelize((0 to n-5).map(x => (x.toLong, x)), 5)
+    val irdd2 = create(sc.parallelize((0 to n-5).map(x => (x.toLong, x)), 10))
+    val irdd3 = irdd.createUsingIndex(prdd)
+    assert(irdd.deleteRDD(prdd).collect().toSet === (n-4 to n).map(x => (x.toLong, x)).toSet)
+    assert(irdd.deleteRDD(irdd2).collect().toSet === (n-4 to n).map(x => (x.toLong, x)).toSet)
+    assert(irdd.deleteRDD(irdd3).collect().toSet === (n-4 to n).map(x => (x.toLong, x)).toSet)
   }
 }
 

--- a/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/amplab/spark/indexedrdd/IndexedRDDSuite.scala
@@ -220,11 +220,17 @@ class UpdatableIndexedRDDSuite extends IndexedRDDSuite {
     val n = 100
     val irdd = pairs(sc, n).cache()
     val prdd = sc.parallelize((0 to n-5).map(x => (x.toLong, x)), 5)
+    val prdd2 = sc.parallelize(Array((0L, 0), (1L, 1), (1L, 1)))
     val irdd2 = create(sc.parallelize((0 to n-5).map(x => (x.toLong, x)), 10))
     val irdd3 = irdd.createUsingIndex(prdd)
+    val irdd4 = create(sc.parallelize((0 to n).map(x => (x.toLong, x)), 10))
+    val empty = sc.parallelize(Seq.empty[(Long, Long)])
     assert(irdd.deleteRDD(prdd).collect().toSet === (n-4 to n).map(x => (x.toLong, x)).toSet)
     assert(irdd.deleteRDD(irdd2).collect().toSet === (n-4 to n).map(x => (x.toLong, x)).toSet)
     assert(irdd.deleteRDD(irdd3).collect().toSet === (n-4 to n).map(x => (x.toLong, x)).toSet)
+    assert(irdd.deleteRDD(empty).collect().toSet === irdd.collect().toSet)
+    assert(irdd.deleteRDD(irdd4).collect().toSet === Set.empty)
+    assert(irdd.deleteRDD(prdd2).collect().toSet === (2 to n).map(x => (x.toLong, x)).toSet)
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
Added a `deleteRDD` method to `IndexedRDD`, which will delete elements that have the same keys as elements from another IndexedRDD or PairRDD.